### PR TITLE
Feat: Version strings can now be read from complex multiline files.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,11 @@ inputs:
     description: 'Template used for updating metadata file'
     required: true
     default: 'version := "%d.%d.%d"'
+  generic_merge_version_file:
+    description: "Don't overwrite the entire version file, but merge using the template pattern"
+    type: boolean
+    required: false
+    default: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -30,6 +35,7 @@ runs:
     PACKAGR_ENGINE_GIT_AUTHOR_NAME: ${{ inputs.author_name }}
     PACKAGR_ENGINE_GIT_AUTHOR_EMAIL: ${{ inputs.author_email }}
     CUSTOM_WORKING_DIRECTORY: ${{ inputs.cwd }}
+    PACKAGR_GENERIC_MERGE_VERSION_FILE: ${{ inputs.generic_merge_version_file }}
 branding:
   icon: 'tag'
   color: 'blue'


### PR DESCRIPTION
Allows for users to only match a single line for the version string in a multiline file, using the config option: PACKAGR_GENERIC_MERGE_VERSION_FILE

Also update the CI to be working as well.

Relates to: https://github.com/PackagrIO/bumpr/pull/8

Requires to be merged first: https://github.com/PackagrIO/releasr/pull/7